### PR TITLE
Fixed compatibility issue with Email Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/woocommerce/woocommerce-product-bundles-bundle-variations.git"
 	},
 	"license": "GPL-3.0+",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"homepage": "https://woocommerce.com/products/product-bundles/",
 	"main": "Gruntfile.js",
 	"devDependencies": {

--- a/product-bundles-variation-bundles.php
+++ b/product-bundles-variation-bundles.php
@@ -3,7 +3,7 @@
  * Plugin Name: Product Bundles - Variation Bundles
  * Plugin URI: https://docs.woocommerce.com/document/bundles/bundles-extensions/
  * Description: Free mini-extension for WooCommerce Product Bundles that allows you to map variations to Product Bundles.
- * Version: 2.0.1
+ * Version: 2.0.2
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  *
@@ -11,11 +11,11 @@
  * Domain Path: /languages/
  *
  * Requires at least: 6.2
- * Tested up to: 6.6
+ * Tested up to: 6.8
  * Requires PHP: 7.4
  *
  * WC requires at least: 8.2
- * WC tested up to: 9.1
+ * WC tested up to: 9.8
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/product-bundles-variation-bundles.php
+++ b/product-bundles-variation-bundles.php
@@ -642,7 +642,7 @@ class WC_PB_Variable_Bundles {
 
 		$parent_product = self::get_variation_parent( $variation );
 
-		if ( ! $parent_product || 'none' === $parent_product->get_tax_status() ) {
+		if ( ! is_a( $parent_product, 'WC_Product' ) || 'none' === $parent_product->get_tax_status() ) {
 			return $tax_class;
 		}
 

--- a/product-bundles-variation-bundles.php
+++ b/product-bundles-variation-bundles.php
@@ -33,7 +33,7 @@ class WC_PB_Variable_Bundles {
 	 *
 	 * @var string
 	 */
-	public static $version = '2.0.1';
+	public static $version = '2.0.2';
 
 	/**
 	 * Min required PB version.
@@ -642,7 +642,7 @@ class WC_PB_Variable_Bundles {
 
 		$parent_product = self::get_variation_parent( $variation );
 
-		if ( 'none' === $parent_product->get_tax_status() ) {
+		if ( ! $parent_product || 'none' === $parent_product->get_tax_status() ) {
 			return $tax_class;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, product, bundles, map, variation
 Requires at least: 6.2
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 WC requires at least: 8.2
 WC tested up to: 9.1
 License: GNU General Public License v3.0
@@ -41,7 +41,10 @@ This plugin requires the official [WooCommerce Product Bundles](https://woocomme
 
 == Changelog ==
 
-= 2.0.0 =
+= 2.0.2 =
+* Fix - Fixed compatibility issue with Email Improvements.
+
+= 2.0.1 =
 * Tweak - Updated author links.
 
 = 2.0.0 =


### PR DESCRIPTION
### Description 

Closes #20 
Closes STRPROD-307

This PR resolves a fatal error that was triggered when Variation Images was enabled and a merchant tried to preview an order e-mail. The reason why it was happening was that we didn't check if a product was `WC_Product` before calling product methods on it. 

### Testing steps

1. Enable e-mail improvements under WooCommerce > Settings > Advanced > Featured.
2. Go to WooCommerce > Settings > Email and click to preview the Completed Order e-mail. 
3. See a fatal error instead of a preview. 
4. Apply the patch. 
5. Refresh the page and ensure that the preview is now correctly displayed.